### PR TITLE
typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,7 +362,7 @@ endforeach()
 # must link them explicitly for downstream FFI consumers.
 set(wxWidgets_BUILTIN_LIBS wxzlib wxpng wxjpeg wxexpat wxscintilla wxlexilla)
 
-# webp uses its upstream CMake target names (wx_set_builtin_target_ouput_name
+# webp uses its upstream CMake target names (wx_set_builtin_target_output_name
 # only renames the output file, not the CMake target)
 list(APPEND wxWidgets_BUILTIN_LIBS webp webpdemux sharpyuv)
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -45,6 +45,7 @@ colourful = "colourful"
 colours = "colours"
 licence = "licence"
 minimise = "minimise"
+minimised = "minimised"
 pluralise = "pluralise"
 theater = "theatre"
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,56 @@
+# typos spell checker configuration
+# See: https://github.com/crate-ci/typos
+
+[files]
+# Exclude third-party code and generated files
+extend-exclude = [
+    "scripts",
+    "src/pugixml/",
+    "frozen/",
+    "**/*.wxui",
+    "src/helptext/data/cppmark/src/entities.inc"
+]
+
+[default]
+# Locale setting
+locale = "en-us"
+
+# Ignore any word containing an ampersand (UI accelerators like "Styl&e" or "Striket&hrough")
+extend-ignore-re = [
+    "\\b\\w*&\\w*\\b",
+]
+
+# Custom dictionary additions
+[default.extend-words]
+# Intentional typos
+
+# Intentional abbreviations used in code
+UE = "UE"  # Abbreviation for wxUiEditor (wxUE)
+parms = "parms"  # Common abbreviation for parameters
+
+# Technical terms and proper nouns
+SEH = "SEH"  # Structured Exception Handling (Windows)
+
+# wxWidgets uses British spellings
+Behaviour = "Behaviour"
+CENTRE = "CENTRE"
+Centre = "Centre"
+Colour = "Colour"
+Colours = "Colours"
+behaviour = "behaviour"
+centre = "centre"
+colour = "colour"
+coloured = "coloured"
+colourful = "colourful"
+colours = "colours"
+licence = "licence"
+minimise = "minimise"
+pluralise = "pluralise"
+theater = "theatre"
+
+# wxWidgets misspellings
+MINIMISE = "MINIMISE"
+
+# Third-party or generated identifiers that aren't actually typos
+[default.extend-identifiers]
+# These get checked as whole identifiers before word-splitting

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -53,7 +53,7 @@ C, however, has a well-defined calling convention that virtually every programmi
 |------|---------|
 | `kwx_wrapper.h` | Precompiled header with all wxWidgets includes and helper classes. Contains `wxClosure`, `wxCallback`, and derived classes for callbacks/events. |
 | `kwx_def.h` | Export macros (`EXPORT`, `WXFFI_EXPORT`) for cross-platform DLL building. |
-| `kwx_types.h` | Type macros that add semantic meaning to function signatures (`TClass`, `TString`, `TPoint`, etc.). Enables foreign language tools to generate proper marshalling code. |
+| `kwx_types.h` | Type macros that add semantic meaning to function signatures (`TClass`, `TString`, `TPoint`, etc.). Enables foreign language tools to generate proper marshaling code. |
 | `kwx_glue.h` | All C wrapper function declarations. This is the main "API" header that foreign languages reference. |
 | `kwx_grid.h` | Callback types and helper class for custom grid data sources. |
 
@@ -80,7 +80,7 @@ Every wxWidgets class method is wrapped following this pattern:
 
 ```cpp
 // Constructor - returns pointer to new object
-EXPORT wxButton* wxButton_Create(wxWindow* parent, int id, wxString* label, 
+EXPORT wxButton* wxButton_Create(wxWindow* parent, int id, wxString* label,
                                   int x, int y, int w, int h, long style)
 {
     return new wxButton(parent, id, *label, wxPoint(x, y), wxSize(w, h), style);
@@ -115,7 +115,7 @@ wxWidgets uses an event system for GUI callbacks. kwxFFI bridges this with:
 ### wxClosure
 A reference-counted wrapper around a foreign function pointer and its associated data. When an event occurs, the closure is invoked with the event object.
 
-### wxCallback  
+### wxCallback
 Connects to the wxWidgets event system. When an event fires, the callback invokes its associated closure.
 
 ### Event Type Exports

--- a/include/kwx_classes.h
+++ b/include/kwx_classes.h
@@ -996,7 +996,7 @@ void wxBrush_SetStipple(TSelf(wxBrush) pObject, TClass(wxBitmap) stipple);
 void wxBrush_SetStyle(TSelf(wxBrush) pObject, int style);
 
 TClassDefExtend(wxBufferedDC, wxDC) TClass(wxBufferedDC)
-    wxBufferedDC_CreateByDCAndSize(TClass(wxDC) dc, TSize(width, hight), int style);
+    wxBufferedDC_CreateByDCAndSize(TClass(wxDC) dc, TSize(width, height), int style);
 TClass(wxBufferedDC)
     wxBufferedDC_CreateByDCAndBitmap(TClass(wxDC) dc, TClass(wxBitmap) bitmap, int style);
 void wxBufferedDC_Delete(TSelf(wxBufferedDC) self);
@@ -5149,7 +5149,7 @@ TClassDef(wxThread)
 void wxTimer_Delete(TSelf(wxTimer) pObject);
 int wxTimer_GetInterval(TSelf(wxTimer) pObject);
 TBool wxTimer_IsOneShot(TSelf(wxTimer) pObject);
-TBool wxTimer_IsRuning(TSelf(wxTimer) pObject);
+TBool wxTimer_IsRunning(TSelf(wxTimer) pObject);
 TBool wxTimer_Start(TSelf(wxTimer) pObject, int interval, TBool oneShot);
 void wxTimer_Stop(TSelf(wxTimer) pObject);
 

--- a/include/kwx_types.h
+++ b/include/kwx_types.h
@@ -5,7 +5,7 @@
 
 /* Types: we use standard pre-processor definitions to add more
    type information to the C signatures. These 'types' can be
-   either read by other tools to automatically generate a marshalling
+   either read by other tools to automatically generate a marshaling
    layer for foreign languages, or you can define the macros in such
    a way that they contain more type information while compiling the
    library itself.

--- a/src/wx_dc.cpp
+++ b/src/wx_dc.cpp
@@ -529,9 +529,9 @@ extern "C"
         delete self;
     }
 
-    EXPORT wxBufferedDC* wxBufferedDC_CreateByDCAndSize(wxDC* dc, int width, int hight, int style)
+    EXPORT wxBufferedDC* wxBufferedDC_CreateByDCAndSize(wxDC* dc, int width, int height, int style)
     {
-        return new wxBufferedDC(dc, wxSize(width, hight), style);
+        return new wxBufferedDC(dc, wxSize(width, height), style);
     }
 
     EXPORT wxBufferedDC* wxBufferedDC_CreateByDCAndBitmap(wxDC* dc, wxBitmap* buffer, int style)

--- a/src/wx_rc.cpp
+++ b/src/wx_rc.cpp
@@ -164,7 +164,7 @@ extern "C"
         return wxXmlResource::Get();
     }
 
-// BUILD_XRCGETCTRL_FN constructs functions for geting control pointers out of
+// BUILD_XRCGETCTRL_FN constructs functions for getting control pointers out of
 // window hierarchies created from XRC files. The functions themselves
 #define BUILD_XRCGETCTRL_FN(type)                                                             \
     EXPORT wx##type* wxXmlResource_Get##type(wxWindow* win, wxString* strId)                  \

--- a/src/wx_timer.cpp
+++ b/src/wx_timer.cpp
@@ -25,7 +25,7 @@ extern "C"
         self->Stop();
     }
 
-    EXPORT bool wxTimer_IsRuning(wxTimer* self)
+    EXPORT bool wxTimer_IsRunning(wxTimer* self)
     {
         return self->IsRunning();
     }


### PR DESCRIPTION
This PR adds the typos spell checker and fixes the typos it found in the codebase.

**WARNING:** This changes some of the API calls which were which contained typos and did not match the wxWidgets API.

Some of the other repositories that use kwxFFI also had this spell checker and were flagging the typos.

Currently, this is only running manually, though it can be setup to run as a github action if needed.
